### PR TITLE
#231: Password Reset Spam Prevention

### DIFF
--- a/backend/auth.js
+++ b/backend/auth.js
@@ -309,7 +309,11 @@ function volunteerRegisterEmail(user) {
         console.error(err)
       }
       users.forEach(u => admins.push(u.email))
-      mail.authSend(admins, 'New Volunteer Registered at Enchanted Closet', user.firstName + ' ' + user.lastName + ' just registered as a volunteer! Have a look')
+      mail.authSend(admins, 'New Volunteer Registered at Enchanted Closet', user.firstName + ' ' + user.lastName + ' just registered as a volunteer! Have a look', err => {
+        if (err) {
+          console.error(err)
+        }
+      })
     })
   }
 }

--- a/backend/controllers/users.js
+++ b/backend/controllers/users.js
@@ -239,6 +239,7 @@ module.exports.update = async (req, res, next) => {
       }
       if (matchesComplexityRequirements(req.body.data['password'])) {
         newProps['password'] = hash.genNew(req.body.data.password)
+        newProps.passwordReset = false
       }
     })
   }


### PR DESCRIPTION
Don't allow user to reset their password if the last password reset was done by the system. They should already have an email with their new password. This will prevent users from being spammed with 100s of emails.

# Overview

- Add statement to check for `passwordReset` field
- Refactored `gmailAuth` to propagate errors up the stack
- Converted clients of `gmailAuth` to use callbacks and handle errors
- Reset `passwordReset` field on admin changing password
- Error messages are sent to the frontend correctly

## Refactoring `gmailAuth`

`gmailAuth` fails silently if there is an error sending an email. This is bad because the `resetPassword` route would change the user's password without notifying the user.

`gmailAuth` was refactored to propagate errors to clients asynchronously via callbacks.

## Logic changes to `resetPassword`

- Previously: Find user, create new password, *store in DB, send email*
- Now: Find user, create new password, *send email, store in DB*

This means if the email fails the send, we will not change the user's password in our DB. This is what we want.