### PR TITLE
# Backend unified error codes

### DIFF
--- a/backend/routes.js
+++ b/backend/routes.js
@@ -75,7 +75,8 @@ router.use((req, res, next) => {
     })
     return res.status(200).json(response)
   } else if (res.locals.error) { // Any errors thrown are be handled below, but because we're bad not all errors are thrown >:(
-    let statusCode = res.locals.error.code || 500
+    let statusCode = res.locals.error.code || res.locals.error.status
+    statusCode = statusCode || 500
     if (res.locals.error.msg instanceof Error) {
       // Extract message from Error object
       res.locals.error.msg = res.locals.error.msg.message


### PR DESCRIPTION
Backend error codes are sometimes stored in the `status` field, sometimes in the `code` field.

Change error handler to check both

*No zenhub issue for this*