### PR TITLE
Fix errors being dismissed early

### DIFF
--- a/frontend/actions/loading.js
+++ b/frontend/actions/loading.js
@@ -52,7 +52,7 @@ export function setErrorMessage (message) { // sad repetition
 // Timeout
 export function messageWrap (dispatch, message) {
   dispatch(setMessage(message))
-  setTimeout(() => dispatch(clearAllMessages()), 3000) //
+  setTimeout(() => dispatch(clearAllMessages()), 3000)
 }
 
 export function errorWrap (dispatch, message) {

--- a/frontend/reducers/index.js
+++ b/frontend/reducers/index.js
@@ -17,31 +17,51 @@ function rootReducer (state = require('../static/defaultState'), action) {
       })
 
     case types.CLEAR_ERRORS:
+      const prevErrorCount = state.numErrors ? state.numErrors : 0
+      if (prevErrorCount > 1) {
+        return Object.assign({}, state, {
+          numErrors: prevErrorCount - 1
+        })
+      }
+      // Only clear error message after action is called on the last error
       return Object.assign({}, state, {
         error: null,
-        errorMessage: null
+        errorMessage: null,
+        numErrors: 0
       })
 
     case types.CLEAR_ALL_MESSAGES:
+      const prevMessageCount = state.numMessages ? state.numMessages : 0
+      if (prevMessageCount > 1) {
+        return Object.assign({}, state, {
+          numMessages: prevMessageCount - 1
+        })
+      }
+      // Only clear messages after action is called on the last message
       return Object.assign({}, state, {
         error: null,
         errorMessage: null,
-        message: null
+        message: null,
+        numMessages: 0
       })
 
     case types.SET_MESSAGE: {
+      const prevMessageCount = state.numMessages ? state.numMessages : 0
       return Object.assign({}, state, {
         error: null,
         errorMessage: null,
-        message: action.message
+        message: action.message,
+        numMessages: prevMessageCount + 1 // Keep track of the number of active messages
       })
     }
 
     case types.SET_ERROR_MESSAGE: {
+      const prevErrorCount = state.numErrors ? state.numErrors : 0
       return Object.assign({}, state, {
         error: null, // hmmm
         errorMessage: action.message,
-        message: null
+        message: null,
+        numErrors: prevErrorCount + 1 // Keep track of the number of active errors
       })
     }
 
@@ -177,20 +197,19 @@ function rootReducer (state = require('../static/defaultState'), action) {
         events: newEvents,
         errorMessage: null }
     }
-    case types.USER_UPDATE:{
+    case types.USER_UPDATE: {
       return Object.assign({}, state, {
         user: { ...(state.user ? state.user : null), ...action.user },
-        newUser:{...action.user},
+        newUser: { ...action.user },
         errorMessage: null
       })
     }
-    case types.ADMIN_USER_CREATE:{
+    case types.ADMIN_USER_CREATE: {
       return Object.assign({}, state, {
-        newUser:{...action.user},
+        newUser: { ...action.user },
         errorMessage: null
       })
     }
-
 
     case types.USER_AUTHENTICATED:
       return Object.assign({}, state, {


### PR DESCRIPTION
Modified the redux state to keep track of the current number of active errors and messages.

`CLEAR_ERROR` and `CLEAR_MESSAGE` only dismiss the error/message if all active errors and messages have been dismissed.

# Testing Done

- Manual testing of multiple errors via the UI
- Manual testing of reset password success/fail
- Manual inspection of the redux state to ensure counters were correct
- Manual testing of event update via the UI